### PR TITLE
Enhance ready check by making sure there are actually items

### DIFF
--- a/src/main/groovy/gg/xp/xivgear/dataapi/datamanager/DataManager.groovy
+++ b/src/main/groovy/gg/xp/xivgear/dataapi/datamanager/DataManager.groovy
@@ -302,7 +302,11 @@ class DataManager implements AutoCloseable {
 			return false
 		}
 		try {
-			dataFuture.get()
+			FullData data = dataFuture.get()
+			if (data.items.isEmpty()) {
+				return false
+			}
+			return true
 		}
 		catch (Throwable t) {
 			return false


### PR DESCRIPTION
If there is a bug that prevents items from being deserialized correctly, this should prevent the pod from reporting as ready when it hasn't properly loaded the data yet.