### PR TITLE
Multi-job support for items endpoinrt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,12 +76,17 @@ dependencies {
 	// Local for testing
 	implementation("io.micronaut.objectstorage:micronaut-object-storage-local")
 
-
+	testImplementation "io.micronaut.test:micronaut-test-junit5:1.1.5"
+	testImplementation "io.micronaut:micronaut-inject-groovy"
+	testImplementation "io.micronaut:micronaut-http-client"
 }
 
 test {
+	systemProperties["junit.jupiter.execution.parallel.enabled"] = true
+	systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
 	useJUnitPlatform()
 	systemProperties['xivapi.baseUri'] = System.getProperty("xivapi.baseUri") ?: 'https://bm.xivgear.app/api/1'
+
 }
 
 application {

--- a/src/main/groovy/gg/xp/xivgear/dataapi/endpoints/ItemsEndpoint.groovy
+++ b/src/main/groovy/gg/xp/xivgear/dataapi/endpoints/ItemsEndpoint.groovy
@@ -14,6 +14,10 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Produces
 import io.swagger.v3.oas.annotations.Operation
 
+/**
+ * Endpoint for items. Supports querying items for multiple jobs. The key type is defined as a Set of job names, so that
+ * order does not matter. i.e. job=WHM,AST will cache the same as job=AST,WHM.
+ */
 @Context
 @Controller("/Items")
 @CompileStatic

--- a/src/main/groovy/gg/xp/xivgear/dataapi/endpoints/ItemsEndpoint.groovy
+++ b/src/main/groovy/gg/xp/xivgear/dataapi/endpoints/ItemsEndpoint.groovy
@@ -17,14 +17,14 @@ import io.swagger.v3.oas.annotations.Operation
 @Context
 @Controller("/Items")
 @CompileStatic
-class ItemsEndpoint extends BaseDataEndpoint<String, Response> {
+class ItemsEndpoint extends BaseDataEndpoint<Set<String>, Response> {
 
 	ItemsEndpoint(DataManager dm) {
 		super(dm)
 	}
 
 	@TupleConstructor(includeFields = true)
-	private static class Response {
+	static class Response {
 		@SuppressWarnings('unused')
 		final List<Item> items
 	}
@@ -33,13 +33,17 @@ class ItemsEndpoint extends BaseDataEndpoint<String, Response> {
 	@Operation(summary = "Get applicable gear items")
 	@Get("/")
 	@Produces(MediaType.APPLICATION_JSON)
-	HttpResponse<Response> items(HttpRequest<?> request, String job) {
-		return makeResponse(request, job)
+	HttpResponse<Response> items(HttpRequest<?> request, List<String> job) {
+		return makeResponse(request, job as Set<String>)
 	}
 
 	@Override
-	protected Response getContent(FullData fd, String job) {
-		List<Item> items = fd.items.findAll { it.classJobCategory.jobs[job] }
+	protected Response getContent(FullData fd, Set<String> jobs) {
+		List<Item> items = fd.items.findAll {
+			jobs.any { job ->
+				it.classJobCategory.jobs[job]
+			}
+		}
 		return new Response(items)
 	}
 }

--- a/src/main/groovy/gg/xp/xivgear/dataapi/models/ItemBase.java
+++ b/src/main/groovy/gg/xp/xivgear/dataapi/models/ItemBase.java
@@ -23,7 +23,7 @@ public interface ItemBase extends XivApiObject {
 
 	Icon getIcon();
 
-	// Ignored because of another method providing this
+	// Ignored because of another method providing this. See Item.getClassJobs()
 	@JsonIgnore
 	ClassJobCategory getClassJobCategory();
 

--- a/src/test/groovy/gg/xp/xivgear/dataapi/datamanager/EndpointTest.groovy
+++ b/src/test/groovy/gg/xp/xivgear/dataapi/datamanager/EndpointTest.groovy
@@ -1,0 +1,84 @@
+package gg.xp.xivgear.dataapi.datamanager
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import groovy.transform.CompileStatic
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.function.Executable
+
+@CompileStatic
+@MicronautTest
+class EndpointTest {
+
+	@Singleton
+	@Inject
+	EmbeddedServer server
+
+	@Inject
+	@Client
+	HttpClient client
+
+	@Inject
+	DataManager dm
+
+	private static final class ItemResponseDummy {
+		@JsonProperty
+		List<ItemDummy> items
+	}
+
+	private static final class ItemDummy {
+		@JsonProperty
+		List<String> classJobs
+	}
+
+	@Test
+	@Timeout(120)
+	void testSingleJobItems() {
+		dm.dataFuture.get()
+		HttpRequest<?> req = HttpRequest.GET(server.URL.toString() + "/Items?job=WHM")
+		String singleJobResponseRaw = client.toBlocking().exchange(req, String).body()
+		ItemResponseDummy singleJobResponse = client.toBlocking().exchange(req, ItemResponseDummy).body()
+		Assertions.assertAll(
+				"should only contain WHM items",
+				singleJobResponse.items.collect { item ->
+					return (Executable) { ->
+						Assertions.assertTrue(item.classJobs.contains("WHM"))
+					}
+				}
+		)
+		Assertions.assertFalse singleJobResponse.items.empty
+	}
+
+	@Test
+	@Timeout(120)
+	void testMultiJobItems() {
+		dm.dataFuture.get()
+		HttpRequest<?> req = HttpRequest.GET(server.URI.resolve("/Items?job=WHM,PLD,MNK"))
+		ItemResponseDummy multiJobResponse = client.toBlocking().exchange(req, ItemResponseDummy).body()
+		Assertions.assertAll(
+				"should only contain WHM items",
+				multiJobResponse.items.collect { item ->
+					return (Executable) { ->
+						Assertions.assertTrue(
+								item.classJobs.contains('WHM')
+										|| item.classJobs.contains('PLD')
+										|| item.classJobs.contains('MNK')
+						)
+					}
+				}
+		)
+		Assertions.assertFalse multiJobResponse.items.empty
+		// Make sure that every job has its items here
+		Assertions.assertFalse multiJobResponse.items.findAll { it.classJobs.contains('WHM') }.empty
+		Assertions.assertFalse multiJobResponse.items.findAll { it.classJobs.contains('PLD') }.empty
+		Assertions.assertFalse multiJobResponse.items.findAll { it.classJobs.contains('MNK') }.empty
+	}
+}


### PR DESCRIPTION
- Allows multiple jobs on Items endpoint, separated by comma. e.g. `GET /Items?job=WHM,AST`, or by specifying the parameter multiple times, e.g. `GET /Items?job=WHM&job=AST`
- Adds endpoint tests
- Enables parallel tests

The intent is to enable multi-job sheets.