### PR TITLE
Acquisition source fixes part 1

### DIFF
--- a/src/main/groovy/gg/xp/xivgear/dataapi/datamanager/FullData.groovy
+++ b/src/main/groovy/gg/xp/xivgear/dataapi/datamanager/FullData.groovy
@@ -23,7 +23,7 @@ class FullData implements Serializable {
 	// The persistence later avoids conflicts between concurrently-running versions by
 	// using a different object storage key based on the serialVersionUID
 	@Serial
-	static final long serialVersionUID = 18
+	static final long serialVersionUID = 19
 
 	final List<GameVersion> versions
 	final List<BaseParam> baseParams

--- a/src/main/groovy/gg/xp/xivgear/dataapi/gear/Expansion.groovy
+++ b/src/main/groovy/gg/xp/xivgear/dataapi/gear/Expansion.groovy
@@ -7,8 +7,17 @@ enum Expansion {
 	Endwalker(560, 570, 600),
 	Dawntrail(690, 700, 730)
 
+	/**
+	 * The level of the basic artifact armor.
+	 */
 	final int artifactLevel
+	/**
+	 * The level of the basic (non-capped) tome gear.
+	 */
 	final int basicTomeLevel
+	/**
+	 * The level of raid tier items. Assumed to be 30 ilvls apart.
+	 */
 	final List<Integer> raidTierLevels
 
 	private Expansion(int artifactLevel, int basicTomeLevel, int firstRaidTierLevel) {

--- a/src/main/groovy/gg/xp/xivgear/dataapi/gear/GearSource.groovy
+++ b/src/main/groovy/gg/xp/xivgear/dataapi/gear/GearSource.groovy
@@ -15,8 +15,12 @@ class GearSource {
 			switch (rarity) {
 				case 1: {
 					// Normal item
-					// For gear items, this means it is crafted
-					return Crafted
+					// For most gear items, this means it is crafted. However, things like pre-order earrings are an exception.
+					boolean isCraftable = fd.itemsWithRecipes.contains(rowId)
+					if (isCraftable) {
+						return Crafted
+					}
+					return Other
 				}
 				case 2: {
 					// Green item
@@ -34,6 +38,10 @@ class GearSource {
 							return Crafted
 						}
 						else {
+							// Bozjan Earring
+							if (rowId == 31393) {
+								return FieldOperation
+							}
 							return Dungeon
 						}
 					}
@@ -72,6 +80,9 @@ class GearSource {
 						if (name.contains("Ultimate")) {
 							return Ultimate
 						}
+						else if (ilvl == 375 && name.endsWith("Ultima")) {
+							return Ultimate
+						}
 						else if (name.contains("Exquisite")) {
 							return Criterion
 						}
@@ -99,6 +110,11 @@ class GearSource {
 							return ExtremeTrial
 						}
 						else {
+							// Memoria Miseria Extreme
+							if (ilvl == 480 && name.startsWith("Idealized")) {
+								// TODO: Should this be "Relic" or "Extreme"?
+								return ExtremeTrial
+							}
 							// TODO: shops needed for this
 							return Unknown
 //							boolean hasShop = true
@@ -113,6 +129,15 @@ class GearSource {
 						}
 					}
 					else if (GearLevels.isExTrialLevel(ilvl) && isWeapon) {
+						if (ilvl == 365 && name.startsWith("Empyrean")) {
+							return DeepDungeon
+						}
+						else if (ilvl == 625 && name.startsWith("Enaretos")) {
+							return DeepDungeon
+						}
+						else if (ilvl == 755 && name.startsWith("Sacramental")) {
+							return DeepDungeon
+						}
 						return ExtremeTrial
 					}
 					break

--- a/src/main/groovy/gg/xp/xivgear/dataapi/models/GearAcquisitionSource.java
+++ b/src/main/groovy/gg/xp/xivgear/dataapi/models/GearAcquisitionSource.java
@@ -14,6 +14,8 @@ public enum GearAcquisitionSource {
 	Artifact,
 	AllianceRaid,
 	Criterion,
+	DeepDungeon,
+	FieldOperation,
 	Other,
 	Custom,
 	Unknown

--- a/src/test/groovy/gg/xp/xivgear/dataapi/datamanager/DatamanagerTest.groovy
+++ b/src/test/groovy/gg/xp/xivgear/dataapi/datamanager/DatamanagerTest.groovy
@@ -88,6 +88,25 @@ class DatamanagerTest {
 			// The game files store +haste (i.e. faster) as a negative modifier
 			Assertions.assertEquals(-3, augLawOrderHealChest.baseParamMapSpecial[47])
 		}
+		var assertAcqSrc = { int itemId, GearAcquisitionSource acqSource ->
+			var item = fd.items.find { it.rowId == itemId }
+			Assertions.assertEquals acqSource, item.acquisitionSource
+		};
+		// More acquisition source tests
+		{
+			// Test Memoria Miseria Ex acquisition source
+			assertAcqSrc 30168, GearAcquisitionSource.ExtremeTrial
+			// Empyrean (SB deep dungeon)
+			assertAcqSrc 27380, GearAcquisitionSource.DeepDungeon
+			// Enaretos (Eureka Orthos)
+			assertAcqSrc 39221, GearAcquisitionSource.DeepDungeon
+			// Sacramental (Pilgrim's Traverse)
+			assertAcqSrc 47065, GearAcquisitionSource.DeepDungeon
+			// Bozjan Earring
+			assertAcqSrc 31393, GearAcquisitionSource.FieldOperation
+			// Azeyma's Earring (Preorder)
+			assertAcqSrc 41081, GearAcquisitionSource.Other
+		}
 
 		// Now serialize and de-serialize
 		byte[] dataSerial


### PR DESCRIPTION
Relates to https://github.com/xiv-gear-planner/gear-planner/issues/861

This fixes:
- Pre-order earrings
- Weapon's Refrain weapons
- Idealized gear
- Empyrean/Enaretos/Scramental gear