### PR TITLE
Fix FSH offhands not being in data API

### DIFF
--- a/src/main/groovy/gg/xp/xivgear/dataapi/datamanager/DataManager.groovy
+++ b/src/main/groovy/gg/xp/xivgear/dataapi/datamanager/DataManager.groovy
@@ -266,6 +266,10 @@ class DataManager implements AutoCloseable {
 							& or(eq("ClassJobCategory.BLU", 1))
 							// Filter out aetherial items
 							& ~(eq("Rarity", 7))
+			) | (
+					// FSH offhands
+					eq("ClassJobCategory.FSH", 1)
+							& eq("EquipSlotCategory", 2)
 			)
 
 			List<ItemBase> itemBases = client.getSearchIterator(ItemBase, itemFilter).toList().toSorted { it.rowId }

--- a/src/test/groovy/gg/xp/xivgear/dataapi/datamanager/DatamanagerTest.groovy
+++ b/src/test/groovy/gg/xp/xivgear/dataapi/datamanager/DatamanagerTest.groovy
@@ -107,6 +107,12 @@ class DatamanagerTest {
 			// Azeyma's Earring (Preorder)
 			assertAcqSrc 41081, GearAcquisitionSource.Other
 		}
+		// FSH offhand should be included despite not being high enough ilvl
+		{
+			var fishOH = fd.items.find { it.rowId == 17726 }
+			Assertions.assertNotNull fishOH
+			Assertions.assertEquals 17726, fishOH.rowId
+		}
 
 		// Now serialize and de-serialize
 		byte[] dataSerial


### PR DESCRIPTION
FSH's spearfishing gig is a level 61 ilvl 180 item so it would otherwise be filtered out, but this leaves FSH without any usable offhand items.